### PR TITLE
Fix PHP 7.1 syntax error with string to array conversion

### DIFF
--- a/classes/class-editorial-access-manager.php
+++ b/classes/class-editorial-access-manager.php
@@ -312,6 +312,7 @@ class Editorial_Access_Manager {
 		if ( $allowed_roles === '' ) {
 			// get default allowed roles since we have never saved allowed roles for this post
 
+			$allowed_roles = array();
 			foreach ( $roles as $role_name => $role_array ) {
 				$role = get_role( $role_name );
 


### PR DESCRIPTION
This fixes a fatal PHP error in PHP 7.1 - `Uncaught Error: [] operator not supported for strings` - when PHP tries to assume that it can convert a string into an array on the fly.